### PR TITLE
rebar.config: Fix deps syntax

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,7 +1,7 @@
 {erl_opts, [debug_info, {parse_transform, lager_transform}]}.
 
 {deps, [
-	{lager, ".*", {git, "https://github.com/basho/lager.git", {tag, "3.2.1"}}},
+	{lager, ".*", {git, "https://github.com/erlang-lager/lager", {tag, "3.9.2"}}},
 	{erlando, ".*", {git, "https://github.com/travelping/erlando.git", {branch, "master"}}},
 	{gen_netlink, ".*", {git, "https://github.com/travelping/gen_netlink", {branch, "master"}}},
 	{gtplib, ".*", {git, "https://github.com/travelping/gtplib.git", {branch, "master"}}}

--- a/rebar.config
+++ b/rebar.config
@@ -2,8 +2,8 @@
 
 {deps, [
 	{lager, ".*", {git, "https://github.com/basho/lager.git", {tag, "3.2.1"}}},
-	{erlando, ".*", {git, "https://github.com/travelping/erlando.git", "master"}},
-	{gen_netlink, ".*", {git, "git://github.com/travelping/gen_netlink", "master"}},
+	{erlando, ".*", {git, "https://github.com/travelping/erlando.git", {branch, "master"}}},
+	{gen_netlink, ".*", {git, "https://github.com/travelping/gen_netlink", {branch, "master"}}},
 	{gtplib, ".*", {git, "https://github.com/travelping/gtplib.git", {branch, "master"}}}
 ]}.
 


### PR DESCRIPTION
* Fix git:// protocol not available anymore on github.
* Fix following warning from rebar3: "WARNING: It is recommended to use {branch, Name}, {tag, Tag} or {ref, Ref}, otherwise updating the dep may not work as expected."